### PR TITLE
update notification semantics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,9 @@ env:
   global:
     - GHREPO=github.com/phosphorjs/phosphor-properties
     - secure: TQLKX6JfbAxi5ByOzdwotRq3qnRfehQyV8LuYXQegIOVsp/MzRZrfy0xAJ+Mlutw5N023ON4I8xB4wRSfU49Y2wVBuV8uUzlFmVKQsRq29YTdkLU7KYAtLMyTnqx/NsFKa2rrvbajsZTD79iObrzPJfk7KIqrCEX8Mdn6S+fPDN38ahUDtH7ilXxQgB5aT1iq1qP/W0zKKmFCCoqzmXe6uiA6AISmMtLEFLAJQeAWiwImtwqdctRug9VJloqVq/0fF8h/huki6REecImuIJVw1CQdH+49p5Fwy83WIGOWYfbFLl5Akx5H88f9qGNc18yA8K/3zoosU9nVHyvBFp/rHsqzfJI3NpdNUfSsvGq8cYORReK2+0Zm4DAKv228c9Q/w6uCLZf/lv4BJ7fFRO19K7XXOyHt+JgXC4QTQSKrkDBXeJRdWq9XCGDkrAClysCjz2CEM7wdi4YyWHi6zmfL6vmb0ZZ0M0oAkDiFDkALZhvx1SFksBRA8CPRKpQE5MYG+FKxhcpbT5cZ5qR+OvAtER91hQ4DS5gnLPCbe8nHxJ2XoGD4wTV1iEMA/OXWe4cKYvh9BhN2GALQSGWz+qpZiNakqtdO+69FIr8kCR0LlhCLpJyPM1URf1vvkxpy4cqcPOoHARtqBWKuPisGfvZajq4IfNGK+xUrXvAZ3qSm30=
-before_install:
-  - chmod +x ./scripts/travis_install.sh
-  - chmod +x ./scripts/travis_script.sh
-  - chmod +x ./scripts/travis_after_success.sh
 install:
-  - ./scripts/travis_install.sh
+  - bash ./scripts/travis_install.sh
 script:
-  - ./scripts/travis_script.sh
+  - bash ./scripts/travis_script.sh
 after_success:
-  - ./scripts/travis_after_success.sh
+  - bash ./scripts/travis_after_success.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   matrix:
     - GROUP=
   global:
+    - GHREPO=github.com/phosphorjs/phosphor-properties
     - secure: TQLKX6JfbAxi5ByOzdwotRq3qnRfehQyV8LuYXQegIOVsp/MzRZrfy0xAJ+Mlutw5N023ON4I8xB4wRSfU49Y2wVBuV8uUzlFmVKQsRq29YTdkLU7KYAtLMyTnqx/NsFKa2rrvbajsZTD79iObrzPJfk7KIqrCEX8Mdn6S+fPDN38ahUDtH7ilXxQgB5aT1iq1qP/W0zKKmFCCoqzmXe6uiA6AISmMtLEFLAJQeAWiwImtwqdctRug9VJloqVq/0fF8h/huki6REecImuIJVw1CQdH+49p5Fwy83WIGOWYfbFLl5Akx5H88f9qGNc18yA8K/3zoosU9nVHyvBFp/rHsqzfJI3NpdNUfSsvGq8cYORReK2+0Zm4DAKv228c9Q/w6uCLZf/lv4BJ7fFRO19K7XXOyHt+JgXC4QTQSKrkDBXeJRdWq9XCGDkrAClysCjz2CEM7wdi4YyWHi6zmfL6vmb0ZZ0M0oAkDiFDkALZhvx1SFksBRA8CPRKpQE5MYG+FKxhcpbT5cZ5qR+OvAtER91hQ4DS5gnLPCbe8nHxJ2XoGD4wTV1iEMA/OXWe4cKYvh9BhN2GALQSGWz+qpZiNakqtdO+69FIr8kCR0LlhCLpJyPM1URf1vvkxpy4cqcPOoHARtqBWKuPisGfvZajq4IfNGK+xUrXvAZ3qSm30=
 before_install:
   - chmod +x ./scripts/travis_install.sh

--- a/README.md
+++ b/README.md
@@ -8,26 +8,26 @@ A module for attached property descriptors.
 
 [API Docs](http://phosphorjs.github.io/phosphor-properties/api/)
 
-Phosphor property descriptors encapsulate the following behaviors:
+Phosphor properties encapsulate several behaviors:
 
   - **Creation** - A property value can default to a static scalar
-    value or be lazily created by calling a value factory function.
+    value or be lazily created by invoking a value factory function.
 
-  - **Coercion** - A property can coerce a user-provided value to a
-    value which is guaranteed to be correct based on current state.
+  - **Coercion** - A property can coerce a user-provided value into
+    a value which is guaranteed to be correct based on current state.
 
-  - **Notification** - User code can be notified when the property
-    value changes. The definition of equality can be customized.
+  - **Notification** - User code can be notified when a property
+    value changes.
 
-  - **Attachement** - A property can be defined for *any* object,
-    not just for instances of the defining class. This allows extra
-    state and behavior to be "attached" to arbitrary objects by
-    external consumers of those objects.
+  - **Attachment** - A property can be defined for *any* object, not
+    just for instances of the class which defines the property. This
+    allows for extra state and behavior to be "attached" to arbitrary
+    objects by external consumers of those objects.
 
 These behavioral patterns are extremely useful for managing complexity in
-large applications. However, they are tedious and repetive to implement
-manually. Phopshor properties reduce developer burden by providing these
-behaviors in an efficient, encapsulated, and type-safe form.
+large applications. However, they are tedious and repetitive to implement
+manually. Phosphor properties reduce developer burden by bundling these
+behaviors into an efficient and type-safe form.
 
 Package Install
 ---------------

--- a/README.md
+++ b/README.md
@@ -91,98 +91,6 @@ Usage Examples
 **Note:** This module is fully compatible with Node/Babel/ES6/ES5. Simply
 omit the type declarations when using a language other than TypeScript.
 
-**Raw API:**
-
-Consumers of a class will not typically interact with properties directly.
-The following examples demonstrate the Property API which will be used by
-class authors to define the behavior of a class's properties. Most classes
-will encapsulate property access for the user by exposing the properties
-as getters/setters or static methods. See the subsequent sections for
-recommended design patterns.
-
-```typescript
-import { Property } from 'phosphor-properties';
-
-
-// Any object can be used as a model.
-class Model {
-  constructor(public name: string) { }
-}
-
-var model1 = new Model('foo');
-var model2 = new Model('bar');
-
-
-// simple number property
-var valueProperty = new Property<Model, number>({
-  value: 42,
-});
-valueProperty.get(model1);      // 42
-valueProperty.set(model1, 84);  //
-valueProperty.get(model1);      // 84
-valueProperty.get(model2);      // 42
-
-
-// default value factory
-var listProperty = new Property<Model, number[]>({
-  create: model => [1, 2, 3],
-});
-var l1 = listProperty.get(model1);  // [1, 2, 3]
-var l2 = listProperty.get(model2);  // [1, 2, 3]
-l1 === l2;                          // false
-
-
-// coerce value callback
-var minValue = 0;
-var limitProperty = new Property<Model, number>({
-  value: 0,
-  coerce: (model, value) => Math.max(minValue, value),
-});
-limitProperty.set(model1, -10);  //
-limitProperty.get(model1);       // 0
-limitProperty.set(model1, 42);   //
-limitProperty.get(model1);       // 42
-minValue = 100;                  //
-limitProperty.coerce(model1);    //
-limitProperty.get(model1);       // 100
-
-
-// value changed callback
-var loggingProperty = new Property<Model, number>({
-  value: 0,
-  changed: (model, oldValue, newValue) => {
-    console.log('changed:', model.name, oldValue, newValue);
-  },
-});
-loggingProperty.set(model1, 10);  // changed: 'foo' 0 10
-loggingProperty.set(model1, 42);  // changed: 'foo' 10 42
-
-
-// compare values callback (assume a `deepEqual` function exists)
-var objectProperty = new Property<Model, any>({
-  compare: (oldValue, newValue) => deepEqual(oldValue, newValue),
-  changed: (model, oldValue, newValue) => {
-    console.log('changed:', oldValue, newValue);
-  },
-});
-loggingProperty.set(model1, { a: 1, b: 2 });  // changed: undefined { a: 1, b: 2 }
-loggingProperty.set(model1, { a: 1, b: 2 });  //
-loggingProperty.set(model1, [1, 2, 3]);       // changed: { a: 1, b: 2 } [1, 2, 3]
-loggingProperty.set(model1, [1, 2, 3]);       //
-loggingProperty.set(model1, void 0);          // changed: [1, 2, 3] undefined
-
-
-// value changed signal
-Property.getChanged(model2).connect((sender, args) => {
-  if (args.property === valueProperty) {
-    console.log('value changed:', sender.name, args.oldValue, args.newValue);
-  }
-});
-valueProperty.set(model2, 0);  // value changed: 'bar' 42 0
-```
-
-**Recommended Design Patterns:**
-
 Class authors should strive to maintain consistency in how their classes
 expose properties to consumers. The PhosphorJS project has adopted a set
 of conventions which cover property naming, behavior, and exposure. It is
@@ -198,12 +106,15 @@ When defining a property for use by instances of the **same** class:
 
   - Append the suffix `'Property'` to the static member name.
 
+  - Give the property a `name` which is the same as the static
+    member name, minus the `'Property'` suffix.
+
   - Define a public getter/setter which delegates access to the
     static property. The getter/setter should contain no logic
     outside of delegation to the static property.
 
-  - The name of the getter/setter should be the same as the name
-    of the static property minus the `'Property'` suffix.
+  - The name of the getter/setter should be the same as the `name`
+    given to the property.
 
   - Consumers should normally use the getter/setter to access the
     property, but meta tools and code generators are free to use
@@ -214,6 +125,7 @@ When defining a property for use by instances of the **same** class:
 class MyObject {
 
   static valueProperty = new Property<MyObject, number>({
+    name: 'value',
     value: 42,
     changed: (owner, old, value) => owner._onValueChanged(old, value),
   });
@@ -246,30 +158,29 @@ When defining a property for use by instances of a **different** class:
 
   - Append the suffix `'Property'` to the static member name.
 
+  - Give the property a `name` which is the same as the static
+    member name, minus the `'Property'` suffix.
+
   - Define static methods to get and set the value of the property
     for a particular instance of the owner type. These two methods
     should contain no logic outside of delegation to the static
     property.
 
   - Name the static methods by prepending `'get'` and `'set'` to
-    the capitalized property name. Omit the `'Property'` suffix.
+    the capitalized property `name`.
 
   - Consumers should normally use the static methods to access the
     property, but meta tools and code generators are free to use
     the property API directly. This is why the methods must be
     pure delegates as described above.
 
-This pattern is commonly referred to as an *attached property*. The
-behavior and semantics of the property are defined by one class, but
-the property value belongs to a foreign instance. This pattern is useful
-when creating container objects which must associate container data with
-child objects in a way which doesn't require polluting the child class
-with extraneous data members.
+This pattern is commonly referred to as an *attached property*. The behavior
+and semantics of the property are defined by one class, but the property value
+belongs to a foreign instance. This pattern is useful when creating container
+objects which must associate container data with child objects in a way which
+doesn't require polluting the child class with extraneous data members.
 
 ```typescript
-import { IChangedArgs } from 'phosphor-properties';
-
-
 class MyWidget {
   // ...
 }
@@ -291,22 +202,8 @@ class MyContainer {
   }
 
   addWidget(widget: MyWidget): void {
-    this._addWidget(widget, MyContainer.getStretch(widget));
-    Property.getChanged(widget).connect(this._onWidgetChanged, this);
-  }
-
-  private _addWidget(widget: MyWidget, stretch: number): void {
-    // add the widget with the given stretch factor
-  }
-
-  private _updateWidget(widget: MyWidget, stretch: number): void {
-    // update the widget with the given stretch factor
-  }
-
-  private _onWidgetChanged(sender: MyWidget, args: IChangedArgs): void {
-    if (args.property === MyContainer.stretchProperty) {
-      this._updateWidget(sender, <number>args.newValue);
-    }
+    let stretch = MyContainer.getStretch(widget);
+    // ...
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -145,11 +145,12 @@ When defining a property for use by instances of a **different** class:
     the property API directly. This is why the methods must be
     pure delegates as described above.
 
-This pattern is commonly referred to as an *attached property*. The behavior
-and semantics of the property are defined by one class, but the property value
-belongs to a foreign instance. This pattern is useful when creating container
-objects which must associate container data with child objects in a way which
-doesn't require polluting the child class with extraneous data members.
+A property declared for instances of a different class is referred to as
+an *attached property*. The behavior and semantics of the property are
+defined by one class, but the property value belongs to a foreign instance.
+This pattern is useful when creating container objects which must associate
+container data with child objects in a way which doesn't require polluting
+the child class with extraneous data members.
 
 **Basic Value:**
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ A module for attached property descriptors.
 
 [API Docs](http://phosphorjs.github.io/phosphor-properties/api/)
 
+Phosphor property descriptors encapsulate the following behaviors:
+
+  - **Creation** - A property value can default to a static scalar
+    value or be lazily created by calling a value factory function.
+
+  - **Coercion** - A property can coerce a user-provided value to a
+    value which is guaranteed to be correct based on current state.
+
+  - **Notification** - User code can be notified when the property
+    value changes. The definition of equality can be customized.
+
+  - **Attachement** - A property can be defined for *any* object,
+    not just for instances of the defining class. This allows extra
+    state and behavior to be "attached" to arbitrary objects by
+    external consumers of those objects.
+
+These behavioral patterns are extremely useful for managing complexity in
+large applications. However, they are tedious and repetive to implement
+manually. Phopshor properties reduce developer burden by providing these
+behaviors in an efficient, encapsulated, and type-safe form.
 
 Package Install
 ---------------

--- a/scripts/travis_after_success.sh
+++ b/scripts/travis_after_success.sh
@@ -11,7 +11,7 @@ then
     git config --global user.email "travis@travis-ci.com"
     git config --global user.name "Travis Bot"
 
-    git clone https://github.com/phosphorjs/phosphor-properties.git travis_docs_build
+    git clone https://${GHREPO}.git travis_docs_build
     cd travis_docs_build
     git checkout gh-pages
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,39 +8,30 @@
 'use strict';
 
 import {
-  ISignal, Signal
+  Signal
 } from 'phosphor-signaling';
 
 
 /**
- * The arguments object emitted with a changed signal.
+ * The args object emitted with the change notification signal.
  */
 export
-interface IPropertyChangedArgs<T, U> {
+interface IChangedArgs<T> {
   /**
-   * The property descriptor associated with the change.
+   * The name of the property which was changed.
    */
-  property: Property<T, U>;
+  name: string;
 
   /**
    * The old value of the property.
    */
-  oldValue: U;
+  oldValue: T;
 
   /**
    * The new value of the property.
    */
-  newValue: U;
+  newValue: T;
 }
-
-
-/**
- * This type alias is deprecated.
- *
- * New code should use the [[IPropertyChangedArgs]] interface.
- */
-export
-type IChangedArgs = IPropertyChangedArgs<any, any>;
 
 
 /**
@@ -49,32 +40,48 @@ type IChangedArgs = IPropertyChangedArgs<any, any>;
 export
 interface IPropertyOptions<T, U> {
   /**
+   * The human readable name for the property.
+   *
+   * #### Notes
+   * By convention, this should be the same as the name used to define
+   * the public accessor for the property value.
+   *
+   * This **does not** have an effect on the property lookup behavior,
+   * and multiple properties may share the same name without conflict.
+   */
+  name: string;
+
+  /**
    * The default value for the property.
    *
    * #### Notes
    * This value will be shared among all property owner instances. It
    * should be an immutable value unless a mutable shared singleton
    * is explicitly desired.
+   *
+   * If this is not provided, it defaults to `undefined`.
    */
   value?: U;
 
   /**
    * A factory function used to create the default property value.
    *
+   * #### Notes
    * If provided, this takes precedence over the [[value]] option.
-   * It will be called whenever the property value is required,
-   * but has not yet been set.
+   *
+   * This will be called whenever the property value is required,
+   * but has not yet been set for a given owner.
    */
   create?: (owner: T) => U;
 
   /**
    * A function used to coerce a supplied value into the final value.
    *
+   * #### Notes
    * This will be called whenever the property value is changed, or
    * when the property is explicitly coerced. The return value will
    * be used as the final value of the property.
    *
-   * #### Notes
    * This will **not** be called for the initial default value.
    */
   coerce?: (owner: T, value: U) => U;
@@ -82,11 +89,11 @@ interface IPropertyOptions<T, U> {
   /**
    * A function used to compare two values for equality.
    *
+   * #### Notes
    * This is called to determine if the property value has changed.
    * It should return `true` if the given values are equivalent, or
    * `false` if they are different.
    *
-   * #### Notes
    * If this is not provided, the comparison uses the `===` operator.
    */
   compare?: (oldValue: U, newValue: U) => boolean;
@@ -94,43 +101,30 @@ interface IPropertyOptions<T, U> {
   /**
    * A function called when the property value has changed.
    *
+   * #### Notes
    * This will be invoked when the property value is changed and the
    * comparitor indicates that the old value is not equal to the new
    * value.
    *
-   * #### Notes
    * This will **not** be called for the initial default value.
    *
-   * This will be invoked **before** the changed signals are emitted
-   * on the property owner.
+   * This will be invoked **before** the notify signal is emitted.
    */
   changed?: (owner: T, oldValue: U, newValue: U) => void;
 
   /**
-   * Whether to emit the changed signals when the property changes.
-   *
-   * If this is `true`, the changed signals **will not** be emitted
-   * when the property value changes. This allows for the creation of
-   * private properties which cannot be observed by external code. It
-   * also provides an optimization point for properties which don't
-   * need to be observed.
-   *
-   * The default value is `false`.
-   */
-  silent?: boolean;
-
-  /**
-   * Optional user-defined metadata for the property.
+   * A signal emitted when the property value has changed.
    *
    * #### Notes
-   * The property does not use the metadata for its own purposes. It
-   * exists as convenient storage for supporting external use cases.
+   * This will be bound and emitted on behalf of the owner when the
+   * property is changed and the comparitor indicates that the old
+   * value is not equal to the new value.
    *
-   * By convention, metadata should be defined as an object literal.
+   * This will **not** be emitted for the initial default value.
    *
-   * If not provided, an empty metadata object will be created.
+   * This will be emitted **after** the changed callback is invoked.
    */
-  metadata?: any;
+  notify?: Signal<T, IChangedArgs<U>>;
 }
 
 
@@ -139,27 +133,54 @@ interface IPropertyOptions<T, U> {
  *
  * Properties descriptors can be used to expose a rich interface for an
  * object which encapsulates value creation, coercion, and notification.
+ *
  * They can also be used to extend the state of an object with semantic
  * data from another class.
  *
  * #### Example
  * ```typescript
- * import { Property } from 'phosphor-properties';
+ * import { IChangedArgs, Property } from 'phosphor-properties';
+ *
+ * import { ISignal, Signal } from 'phosphor-signaling';
  *
  * class MyClass {
  *
- *   static myValueProperty = new Property<MyClass, number>({
+ *   static stateChangedSignal = new Signal<MyClass, IChangedArgs<any>>();
+ *
+ *   static valueProperty = new Property<MyClass, number>({
+ *      name: 'value',
  *      value: 0,
  *      coerce: (owner, value) => Math.max(0, value),
  *      changed: (owner, oldValue, newValue) => { console.log(newValue); },
+ *      notify: MyClass.stateChangedSignal,
  *   });
  *
- *   get myValue(): number {
- *     return MyClass.myValueProperty.get(this);
+ *   static textProperty = new Property<MyClass, number>({
+ *      name: 'text',
+ *      value: '',
+ *      coerce: (owner, value) => value.toLowerCase(),
+ *      changed: (owner, oldValue, newValue) => { console.log(newValue); },
+ *      notify: MyClass.stateChangedSignal,
+ *   });
+ *
+ *   get stateChanged(): ISignal<MyClass, IChangedArgs<any>> {
+ *     return MyClass.stateChangedSignal.bind(this);
  *   }
  *
- *   set myValue(value: number) {
- *     MyClass.myValueProperty.set(this, value);
+ *   get value(): number {
+ *     return MyClass.valueProperty.get(this);
+ *   }
+ *
+ *   set value(value: number) {
+ *     MyClass.valueProperty.set(this, value);
+ *   }
+ *
+ *   get text(): string {
+ *     return MyClass.textProperty.get(this);
+ *   }
+ *
+ *   set text(value: string) {
+ *     MyClass.textProperty.set(this, value);
  *   }
  * }
  * ```
@@ -167,90 +188,28 @@ interface IPropertyOptions<T, U> {
 export
 class Property<T, U> {
   /**
-   * A signal emitted when a property value changes.
-   *
-   * #### Notes
-   * This is an attached signal which will be emitted using the owner
-   * of the property value as the sender.
-   *
-   * **See Also:** [[getChanged]]
-   */
-  static changedSignal = new Signal<any, IPropertyChangedArgs<any, any>>();
-
-  /**
-   * Get the bound changed signal for a given property owner.
-   *
-   * @param owner - The object to bind to the changed signal.
-   *
-   * @returns The bound changed signal for the owner.
-   *
-   * #### Notes
-   * This signal will be emitted whenever **any** property value for
-   * the specified owner is changed.
-   *
-   * This signal is emitted **after** the instance changed signal.
-   *
-   * This signal will not be emmited for properties marked as silent.
-   */
-  static getChanged<V>(owner: V): ISignal<V, IPropertyChangedArgs<V, any>> {
-    return Property.changedSignal.bind(owner);
-  }
-
-  /**
    * Construct a new property descriptor.
    *
    * @param options - The options for initializing the property.
    */
-  constructor(options: IPropertyOptions<T, U> = {}) {
+  constructor(options: IPropertyOptions<T, U>) {
+    this._name = options.name;
     this._value = options.value;
     this._create = options.create;
     this._coerce = options.coerce;
     this._compare = options.compare;
     this._changed = options.changed;
-    this._silent = !!options.silent;
-    this._metadata = options.metadata || {};
+    this._notify = options.notify;
   }
 
   /**
-   * Get the metadata for the property.
+   * Get the human readable name for the property.
    *
    * #### Notes
    * This is a read-only property.
    */
-  get metadata(): any {
-    return this._metadata;
-  }
-
-  /**
-   * A signal emitted when the property value changes.
-   *
-   * #### Notes
-   * This is an attached signal which will be emitted using the owner
-   * of the property value as the sender.
-   *
-   * **See Also:** [[getChanged]]
-   */
-  get changedSignal(): Signal<T, IPropertyChangedArgs<T, U>> {
-    return this._changedSignal;
-  }
-
-  /**
-   * Get the bound changed signal for a given property owner.
-   *
-   * @param owner - The object to bind to the changed signal.
-   *
-   * @returns The bound changed signal for the owner.
-   *
-   * #### Notes
-   * This signal will be emitted whenever **this** property value
-   * for the specified owner is changed.
-   *
-   * This signal is emitted **before** the static changed signal.
-   *
-   * This signal will not be emmited for properties marked as silent.
-   */
-  getChanged(owner: T): ISignal<T, IPropertyChangedArgs<T, U>> {
-    return this._changedSignal.bind(owner);
+  get name(): string {
+    return this._name;
   }
 
   /**
@@ -283,9 +242,6 @@ class Property<T, U> {
    * @param value - The value for the property.
    *
    * #### Notes
-   * If this operation causes the property value to change, the
-   * changed signals will be emitted with the owner as sender.
-   *
    * If the value has not yet been set, the default value will be
    * computed and used as the previous value for the comparison.
    */
@@ -307,9 +263,6 @@ class Property<T, U> {
    * @param owner - The property owner of interest.
    *
    * #### Notes
-   * If this operation causes the property value to change, the
-   * changed signals will be emitted with the owner as sender.
-   *
    * If the value has not yet been set, the default value will be
    * computed and used as the previous value for the comparison.
    */
@@ -353,30 +306,30 @@ class Property<T, U> {
    * Run the change notification if the given values are different.
    */
   private _maybeNotify(owner: T, oldValue: U, newValue: U): void {
+    let changed = this._changed;
+    let notify = this._notify;
+    if (!changed && !notify) {
+      return;
+    }
     if (this._compareValue(oldValue, newValue)) {
       return;
     }
-    let changed = this._changed;
     if (changed) {
       changed(owner, oldValue, newValue);
     }
-    if (this._silent) {
-      return;
+    if (notify) {
+      notify.bind(owner).emit({ name: this._name, oldValue, newValue });
     }
-    let args = { property: this, oldValue, newValue };
-    this.getChanged(owner).emit(args);
-    Property.getChanged(owner).emit(args);
   }
 
   private _value: U;
-  private _metadata: any;
-  private _silent: boolean;
+  private _name: string;
   private _pid = nextPID();
   private _create: (owner: T) => U;
   private _coerce: (owner: T, value: U) => U;
+  private _notify: Signal<T, IChangedArgs<U>>;
   private _compare: (oldValue: U, newValue: U) => boolean;
   private _changed: (owner: T, oldValue: U, newValue: U) => void;
-  private _changedSignal = new Signal<T, IPropertyChangedArgs<T, U>>();
 }
 
 
@@ -387,7 +340,7 @@ class Property<T, U> {
  *
  * #### Notes
  * This will clear all property values for the owner, but it will
- * **not** emit any change notifications.
+ * **not** run the change notification for any of the properties.
  */
 export
 function clearPropertyData(owner: any): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ interface IPropertyOptions<T, U> {
    *
    * #### Notes
    * This will be invoked when the property value is changed and the
-   * comparitor indicates that the old value is not equal to the new
+   * comparator indicates that the old value is not equal to the new
    * value.
    *
    * This will **not** be called for the initial default value.
@@ -117,7 +117,7 @@ interface IPropertyOptions<T, U> {
    *
    * #### Notes
    * This will be bound and emitted on behalf of the owner when the
-   * property is changed and the comparitor indicates that the old
+   * property is changed and the comparator indicates that the old
    * value is not equal to the new value.
    *
    * This will **not** be emitted for the initial default value.

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
 
 
 /**
- * The args object emitted with the change notification signal.
+ * The args object emitted with a change notification signal.
  */
 export
 interface IChangedArgs<T> {
@@ -46,8 +46,8 @@ interface IPropertyOptions<T, U> {
    * By convention, this should be the same as the name used to define
    * the public accessor for the property value.
    *
-   * This **does not** have an effect on the property lookup behavior,
-   * and multiple properties may share the same name without conflict.
+   * This **does not** have an effect on the property lookup behavior.
+   * Multiple properties may share the same name without conflict.
    */
   name: string;
 
@@ -94,7 +94,7 @@ interface IPropertyOptions<T, U> {
    * It should return `true` if the given values are equivalent, or
    * `false` if they are different.
    *
-   * If this is not provided, the comparison uses the `===` operator.
+   * If this is not provided, it defaults to the `===` operator.
    */
   compare?: (oldValue: U, newValue: U) => boolean;
 
@@ -129,61 +129,12 @@ interface IPropertyOptions<T, U> {
 
 
 /**
- * A property descriptor for a property on an object.
+ * A property descriptor for a datum belonging to an object.
  *
- * Properties descriptors can be used to expose a rich interface for an
+ * Property descriptors can be used to expose a rich interface for an
  * object which encapsulates value creation, coercion, and notification.
- *
  * They can also be used to extend the state of an object with semantic
- * data from another class.
- *
- * #### Example
- * ```typescript
- * import { IChangedArgs, Property } from 'phosphor-properties';
- *
- * import { ISignal, Signal } from 'phosphor-signaling';
- *
- * class MyClass {
- *
- *   static stateChangedSignal = new Signal<MyClass, IChangedArgs<any>>();
- *
- *   static valueProperty = new Property<MyClass, number>({
- *      name: 'value',
- *      value: 0,
- *      coerce: (owner, value) => Math.max(0, value),
- *      changed: (owner, oldValue, newValue) => { console.log(newValue); },
- *      notify: MyClass.stateChangedSignal,
- *   });
- *
- *   static textProperty = new Property<MyClass, number>({
- *      name: 'text',
- *      value: '',
- *      coerce: (owner, value) => value.toLowerCase(),
- *      changed: (owner, oldValue, newValue) => { console.log(newValue); },
- *      notify: MyClass.stateChangedSignal,
- *   });
- *
- *   get stateChanged(): ISignal<MyClass, IChangedArgs<any>> {
- *     return MyClass.stateChangedSignal.bind(this);
- *   }
- *
- *   get value(): number {
- *     return MyClass.valueProperty.get(this);
- *   }
- *
- *   set value(value: number) {
- *     MyClass.valueProperty.set(this, value);
- *   }
- *
- *   get text(): string {
- *     return MyClass.textProperty.get(this);
- *   }
- *
- *   set text(value: string) {
- *     MyClass.textProperty.set(this, value);
- *   }
- * }
- * ```
+ * data from an unrelated class.
  */
 export
 class Property<T, U> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,6 +213,18 @@ class Property<T, U> {
   }
 
   /**
+   * Get the notify signal for the property.
+   *
+   * #### Notes
+   * This will be `undefined` if no notify signal was provided.
+   *
+   * This is a read-only property.
+   */
+  get notify(): Signal<T, IChangedArgs<U>> {
+    return this._notify;
+  }
+
+  /**
    * Get the current value of the property for a given owner.
    *
    * @param owner - The property owner of interest.

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -27,93 +27,49 @@ describe('phosphor-properties', () => {
 
   describe('Property', () => {
 
-    describe('.changedSignal', () => {
-
-      it('should be a `Signal` instance', () => {
-        expect(Property.changedSignal instanceof Signal).to.be(true);
-      });
-
-    });
-
-    describe('.getChanged', () => {
-
-      it('should get a bound changed signal', () => {
-        var obj = {};
-        var s1 = Property.changedSignal.bind(obj);
-        var s2 = Property.getChanged(obj);
-        expect(s1).to.eql(s2);
-      });
-
-    });
-
     describe('#constructor()', () => {
 
-      it('should accept zero arguments', () => {
-        var p = new Property<Model, number>();
-        expect(p instanceof Property).to.be(true);
-      });
-
       it('should accept a single options argument', () => {
-        var p = new Property<Model, number>({
+        let p = new Property<Model, number>({
+          name: 'p',
           value: 12,
           create: (owner) => 42,
           coerce: (owner, value) => Math.max(0, value),
           compare: (oldValue, newValue) => oldValue === newValue,
           changed: (owner, oldValue, newValue) => { },
+          notify: new Signal<Model, IChangedArgs<number>>(),
         });
         expect(p instanceof Property).to.be(true);
       });
 
     });
 
-    describe('#metadata', () => {
+    describe('#name', () => {
 
-      it('should default to a new empty object', () => {
-        var p1 = new Property<Model, number>();
-        var p2 = new Property<Model, number>();
-        expect(p1.metadata).to.eql({});
-        expect(p2.metadata).to.eql({});
-        expect(p1.metadata).to.eql(p2.metadata);
-        expect(p1.metadata).to.not.be(p2.metadata);
-      });
-
-      it('should use the metadata provided to the constructor', () => {
-        var m = { one: 1, two: 2 };
-        var p = new Property<Model, number>({
-          metadata: m,
-        });
-        expect(p.metadata).to.be(m);
+      it('should be the name provided to the constructor', () => {
+        let p = new Property<Model, number>({ name: 'p' });
+        expect(p.name).to.be('p');
       });
 
       it('should be a read-only property', () => {
-        var p = new Property<Model, number>();
-        expect(() => { p.metadata = {}; }).to.throwException();
+        let p = new Property<Model, number>({ name: 'p' });
+        expect(() => { p.name = 'q'; }).to.throwException();
       });
 
     });
 
-    describe('#changedSignal', () => {
+    describe('#notify', () => {
 
-      it('should be a `Signal` instance', () => {
-        var p = new Property<Model, number>();
-        expect(p.changedSignal instanceof Signal).to.be(true);
+      it('should be the signal provided to the constructor', () => {
+        let notify = new Signal<Model, IChangedArgs<number>>();
+        let p = new Property<Model, number>({ name: 'p', notify });
+        expect(p.notify).to.be(notify);
       });
 
       it('should be a read-only property', () => {
-        var p = new Property<Model, number>();
-        expect(() => { p.changedSignal = null; }).to.throwException();
-      });
-
-    });
-
-    describe('#getChanged', () => {
-
-      it('should get a bound changed signal', () => {
-        var obj = new Model();
-        var p = new Property<Model, number>();
-        var s1 = p.changedSignal.bind(obj);
-        var s2 = p.getChanged(obj);
-        expect(s1).to.eql(s2);
+        let notify = new Signal<Model, IChangedArgs<number>>();
+        let p = new Property<Model, number>({ name: 'p', notify });
+        expect(() => { p.notify = null }).to.throwException();
       });
 
     });
@@ -121,12 +77,12 @@ describe('phosphor-properties', () => {
     describe('#get()', () => {
 
       it('should return the current value of the property', () => {
-        var p1 = new Property<Model, number>();
-        var p2 = new Property<Model, number>();
-        var p3 = new Property<Model, number>();
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
+        let p1 = new Property<Model, number>({ name: 'p1' });
+        let p2 = new Property<Model, number>({ name: 'p2' });
+        let p3 = new Property<Model, number>({ name: 'p3' });
+        let m1 = new Model();
+        let m2 = new Model();
+        let m3 = new Model();
         expect(p1.get(m1)).to.be(void 0);
         expect(p1.get(m2)).to.be(void 0);
         expect(p1.get(m3)).to.be(void 0);
@@ -157,12 +113,12 @@ describe('phosphor-properties', () => {
       });
 
       it('should return the default value if the value is not yet set', () => {
-        var p1 = new Property<Model, number>({ value: 42 });
-        var p2 = new Property<Model, number>({ value: 43 });
-        var p3 = new Property<Model, number>({ value: 44 });
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
+        let p1 = new Property<Model, number>({ name: 'p1', value: 42 });
+        let p2 = new Property<Model, number>({ name: 'p2', value: 43 });
+        let p3 = new Property<Model, number>({ name: 'p3', value: 44 });
+        let m1 = new Model();
+        let m2 = new Model();
+        let m3 = new Model();
         expect(p1.get(m1)).to.be(42);
         expect(p2.get(m1)).to.be(43);
         expect(p3.get(m1)).to.be(44);
@@ -175,14 +131,14 @@ describe('phosphor-properties', () => {
       });
 
       it('should use the default factory if the value is not yet set', () => {
-        var tick = 42;
-        var create = () => tick++;
-        var p1 = new Property<Model, number>({ create: create });
-        var p2 = new Property<Model, number>({ create: create });
-        var p3 = new Property<Model, number>({ create: create });
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
+        let tick = 42;
+        let create = () => tick++;
+        let p1 = new Property<Model, number>({ name: 'p1', create });
+        let p2 = new Property<Model, number>({ name: 'p2', create });
+        let p3 = new Property<Model, number>({ name: 'p3', create });
+        let m1 = new Model();
+        let m2 = new Model();
+        let m3 = new Model();
         expect(p1.get(m1)).to.be(42);
         expect(p2.get(m1)).to.be(43);
         expect(p3.get(m1)).to.be(44);
@@ -195,14 +151,14 @@ describe('phosphor-properties', () => {
       });
 
       it('should prefer the default factory over the default value', () => {
-        var tick = 42;
-        var create = () => tick++;
-        var p1 = new Property<Model, number>({ value: 1, create: create });
-        var p2 = new Property<Model, number>({ value: 1, create: create });
-        var p3 = new Property<Model, number>({ value: 1, create: create });
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
+        let tick = 42;
+        let create = () => tick++;
+        let p1 = new Property<Model, number>({ name: 'p1', value: 1, create });
+        let p2 = new Property<Model, number>({ name: 'p2', value: 1, create });
+        let p3 = new Property<Model, number>({ name: 'p3', value: 1, create });
+        let m1 = new Model();
+        let m2 = new Model();
+        let m3 = new Model();
         expect(p1.get(m1)).to.be(42);
         expect(p2.get(m1)).to.be(43);
         expect(p3.get(m1)).to.be(44);
@@ -215,14 +171,14 @@ describe('phosphor-properties', () => {
       });
 
       it('should not invoke the coerce function', () => {
-        var called = false;
-        var coerce = (m: Model, v: number) => (called = true,  v);
-        var p1 = new Property<Model, number>({ value: 1, coerce: coerce });
-        var p2 = new Property<Model, number>({ value: 1, coerce: coerce });
-        var p3 = new Property<Model, number>({ value: 1, coerce: coerce });
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
+        let called = false;
+        let coerce = (m: Model, v: number) => (called = true,  v);
+        let p1 = new Property<Model, number>({ name: 'p1', value: 1, coerce });
+        let p2 = new Property<Model, number>({ name: 'p2', value: 1, coerce });
+        let p3 = new Property<Model, number>({ name: 'p3', value: 1, coerce });
+        let m1 = new Model();
+        let m2 = new Model();
+        let m3 = new Model();
         p1.get(m1);
         p2.get(m1);
         p3.get(m1);
@@ -236,14 +192,14 @@ describe('phosphor-properties', () => {
       });
 
       it('should not invoke the compare function', () => {
-        var called = false;
-        var compare = (v1: number, v2: number) => (called = true,  v1 === v2);
-        var p1 = new Property<Model, number>({ value: 1, compare: compare });
-        var p2 = new Property<Model, number>({ value: 1, compare: compare });
-        var p3 = new Property<Model, number>({ value: 1, compare: compare });
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
+        let called = false;
+        let compare = (v1: number, v2: number) => (called = true,  v1 === v2);
+        let p1 = new Property<Model, number>({ name: 'p1', value: 1, compare });
+        let p2 = new Property<Model, number>({ name: 'p2', value: 1, compare });
+        let p3 = new Property<Model, number>({ name: 'p3', value: 1, compare });
+        let m1 = new Model();
+        let m2 = new Model();
+        let m3 = new Model();
         p1.get(m1);
         p2.get(m1);
         p3.get(m1);
@@ -257,14 +213,14 @@ describe('phosphor-properties', () => {
       });
 
       it('should not invoke the changed function', () => {
-        var called = false;
-        var changed = () => { called = true; };
-        var p1 = new Property<Model, number>({ value: 1, changed: changed });
-        var p2 = new Property<Model, number>({ value: 1, changed: changed });
-        var p3 = new Property<Model, number>({ value: 1, changed: changed });
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
+        let called = false;
+        let changed = () => { called = true; };
+        let p1 = new Property<Model, number>({ name: 'p1', value: 1, changed });
+        let p2 = new Property<Model, number>({ name: 'p2', value: 1, changed });
+        let p3 = new Property<Model, number>({ name: 'p3', value: 1, changed });
+        let m1 = new Model();
+        let m2 = new Model();
+        let m3 = new Model();
         p1.get(m1);
         p2.get(m1);
         p3.get(m1);
@@ -277,18 +233,19 @@ describe('phosphor-properties', () => {
         expect(called).to.be(false);
       });
 
-      it('should not emit the static `changedSignal`', () => {
-        var called = false;
-        var changed = () => { called = true; };
-        var p1 = new Property<Model, number>({ value: 1 });
-        var p2 = new Property<Model, number>({ value: 1 });
-        var p3 = new Property<Model, number>({ value: 1 });
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
-        Property.getChanged(m1).connect(changed);
-        Property.getChanged(m2).connect(changed);
-        Property.getChanged(m3).connect(changed);
+      it('should not emit the notify signal', () => {
+        let called = false;
+        let changed = () => { called = true; };
+        let notify = new Signal<Model, IChangedArgs<number>>();
+        let p1 = new Property<Model, number>({ name: 'p1', value: 1, notify });
+        let p2 = new Property<Model, number>({ name: 'p1', value: 1, notify });
+        let p3 = new Property<Model, number>({ name: 'p1', value: 1, notify });
+        let m1 = new Model();
+        let m2 = new Model();
+        let m3 = new Model();
+        notify.bind(m1).connect(changed);
+        notify.bind(m2).connect(changed);
+        notify.bind(m3).connect(changed);
         p1.get(m1);
         p2.get(m1);
         p3.get(m1);
@@ -298,22 +255,6 @@ describe('phosphor-properties', () => {
         p1.get(m3);
         p2.get(m3);
         p3.get(m3);
-        expect(called).to.be(false);
-      });
-
-      it('should not emit the instance `changedSignal`', () => {
-        var called = false;
-        var changed = () => { called = true; };
-        var p1 = new Property<Model, number>({ value: 1 });
-        var p2 = new Property<Model, number>({ value: 1 });
-        var p3 = new Property<Model, number>({ value: 1 });
-        var m1 = new Model();
-        p1.getChanged(m1).connect(changed);
-        p2.getChanged(m1).connect(changed);
-        p3.getChanged(m1).connect(changed);
-        p1.get(m1);
-        p2.get(m1);
-        p3.get(m1);
         expect(called).to.be(false);
       });
 
@@ -322,12 +263,12 @@ describe('phosphor-properties', () => {
     describe('#set()', () => {
 
       it('should set the current value of the property', () => {
-        var p1 = new Property<Model, number>();
-        var p2 = new Property<Model, number>();
-        var p3 = new Property<Model, number>();
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
+        let p1 = new Property<Model, number>({ name: 'p1' });
+        let p2 = new Property<Model, number>({ name: 'p2' });
+        let p3 = new Property<Model, number>({ name: 'p3' });
+        let m1 = new Model();
+        let m2 = new Model();
+        let m3 = new Model();
         p1.set(m1, 1);
         p1.set(m2, 2);
         p1.set(m3, 3);
@@ -349,20 +290,20 @@ describe('phosphor-properties', () => {
       });
 
       it('should invoke the changed function if the value changes', () => {
-        var models: Model[] = [];
-        var oldvals: number[] = [];
-        var newvals: number[] = [];
-        var changed = (m: Model, o: number, n: number) => {
+        let models: Model[] = [];
+        let oldvals: number[] = [];
+        let newvals: number[] = [];
+        let changed = (m: Model, o: number, n: number) => {
           models.push(m);
           oldvals.push(o);
           newvals.push(n);
         };
-        var p1 = new Property<Model, number>({ value: 0, changed: changed });
-        var p2 = new Property<Model, number>({ value: 0, changed: changed });
-        var p3 = new Property<Model, number>({ value: 0, changed: changed });
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
+        let p1 = new Property<Model, number>({ name: 'p1', value: 0, changed });
+        let p2 = new Property<Model, number>({ name: 'p2', value: 0, changed });
+        let p3 = new Property<Model, number>({ name: 'p3', value: 0, changed });
+        let m1 = new Model();
+        let m2 = new Model();
+        let m3 = new Model();
         p1.set(m1, 1);
         p1.set(m2, 2);
         p1.set(m3, 3);
@@ -377,24 +318,27 @@ describe('phosphor-properties', () => {
         expect(newvals).to.eql([1, 2, 3, 4, 5, 6, 7, 8, 9]);
       });
 
-      it('should emit the static `changedSignal` if the value changes', () => {
-        var models: Model[] = [];
-        var oldvals: number[] = [];
-        var newvals: number[] = [];
-        var changed = (sender: Model, args: IChangedArgs) => {
+      it('should emit the notify signal if the value changes', () => {
+        let models: Model[] = [];
+        let names: string[] = [];
+        let oldvals: number[] = [];
+        let newvals: number[] = [];
+        let notify = new Signal<Model, IChangedArgs<number>>();
+        let changed = (sender: Model, args: IChangedArgs<number>) => {
           models.push(sender);
+          names.push(args.name);
           oldvals.push(args.oldValue);
           newvals.push(args.newValue);
         };
-        var p1 = new Property<Model, number>({ value: 0 });
-        var p2 = new Property<Model, number>({ value: 0 });
-        var p3 = new Property<Model, number>({ value: 0 });
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
-        Property.getChanged(m1).connect(changed);
-        Property.getChanged(m2).connect(changed);
-        Property.getChanged(m3).connect(changed);
+        let p1 = new Property<Model, number>({ name: 'p1', value: 0, notify });
+        let p2 = new Property<Model, number>({ name: 'p2', value: 1, notify });
+        let p3 = new Property<Model, number>({ name: 'p3', value: 2, notify });
+        let m1 = new Model();
+        let m2 = new Model();
+        let m3 = new Model();
+        notify.bind(m1).connect(changed);
+        notify.bind(m2).connect(changed);
+        notify.bind(m3).connect(changed);
         p1.set(m1, 1);
         p1.set(m2, 2);
         p1.set(m3, 3);
@@ -405,72 +349,40 @@ describe('phosphor-properties', () => {
         p3.set(m2, 8);
         p3.set(m3, 9);
         expect(models).to.eql([m1, m2, m3, m1, m2, m3, m1, m2, m3]);
-        expect(oldvals).to.eql([0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        expect(names).to.eql(['p1', 'p1', 'p1', 'p2', 'p2', 'p2', 'p3', 'p3', 'p3']);
+        expect(oldvals).to.eql([0, 0, 0, 1, 1, 1, 2, 2, 2]);
         expect(newvals).to.eql([1, 2, 3, 4, 5, 6, 7, 8, 9]);
       });
 
-      it('should emit the instance `changedSignal` if the value changes', () => {
-        var models: Model[] = [];
-        var oldvals: number[] = [];
-        var newvals: number[] = [];
-        var changed = (sender: Model, args: IChangedArgs) => {
-          models.push(sender);
-          oldvals.push(args.oldValue);
-          newvals.push(args.newValue);
-        };
-        var p1 = new Property<Model, number>({ value: 0 });
-        var p2 = new Property<Model, number>({ value: 0 });
-        var p3 = new Property<Model, number>({ value: 0 });
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
-        p1.getChanged(m1).connect(changed);
-        p2.getChanged(m2).connect(changed);
-        p3.getChanged(m3).connect(changed);
-        p1.set(m1, 1);
-        p1.set(m2, 2);
-        p1.set(m3, 3);
-        p2.set(m1, 4);
-        p2.set(m2, 5);
-        p2.set(m3, 6);
-        p3.set(m1, 7);
-        p3.set(m2, 8);
-        p3.set(m3, 9);
-        expect(models).to.eql([m1, m2, m3]);
-        expect(oldvals).to.eql([0, 0, 0]);
-        expect(newvals).to.eql([1, 5, 9]);
-      });
-
-      it('should notify in order: function -> instance -> static', () => {
-        var result: string[] = [];
-        var changed1 = () => { result.push('c1'); };
-        var changed2 = () => { result.push('c2'); };
-        var changed3 = () => { result.push('c3'); };
-        var p = new Property<Model, number>({ value: 0, changed: changed1 });
-        var m = new Model();
-        Property.getChanged(m).connect(changed3);
-        p.getChanged(m).connect(changed2);
+      it('should call the changed function before notify signal', () => {
+        let result: string[] = [];
+        let changed = () => { result.push('c1'); };
+        let changed2 = () => { result.push('c2'); };
+        let notify = new Signal<Model, IChangedArgs<number>>();
+        let p = new Property<Model, number>({ name: 'p', value: 0, changed, notify });
+        let m = new Model();
+        notify.bind(m).connect(changed2);
         p.set(m, 42);
-        expect(result).to.eql(['c1', 'c2', 'c3']);
+        expect(result).to.eql(['c1', 'c2']);
       });
 
       it('should use the default factory for old value if value is not yet set', () => {
-        var models: Model[] = [];
-        var oldvals: number[] = [];
-        var newvals: number[] = [];
-        var changed = (m: Model, o: number, n: number) => {
+        let models: Model[] = [];
+        let oldvals: number[] = [];
+        let newvals: number[] = [];
+        let changed = (m: Model, o: number, n: number) => {
           models.push(m);
           oldvals.push(o);
           newvals.push(n);
         };
-        var tick = 42;
-        var create = () => tick++;
-        var p1 = new Property<Model, number>({ create: create, changed: changed });
-        var p2 = new Property<Model, number>({ create: create, changed: changed });
-        var p3 = new Property<Model, number>({ create: create, changed: changed });
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
+        let tick = 42;
+        let create = () => tick++;
+        let p1 = new Property<Model, number>({ name: 'p1', create, changed });
+        let p2 = new Property<Model, number>({ name: 'p2', create, changed });
+        let p3 = new Property<Model, number>({ name: 'p3', create, changed });
+        let m1 = new Model();
+        let m2 = new Model();
+        let m3 = new Model();
         p1.set(m1, 1);
         p1.set(m2, 2);
         p1.set(m3, 3);
@@ -486,22 +398,22 @@ describe('phosphor-properties', () => {
       });
 
       it('should prefer the default factory over default value', () => {
-        var models: Model[] = [];
-        var oldvals: number[] = [];
-        var newvals: number[] = [];
-        var changed = (m: Model, o: number, n: number) => {
+        let models: Model[] = [];
+        let oldvals: number[] = [];
+        let newvals: number[] = [];
+        let changed = (m: Model, o: number, n: number) => {
           models.push(m);
           oldvals.push(o);
           newvals.push(n);
         };
-        var tick = 42;
-        var create = () => tick++;
-        var p1 = new Property<Model, number>({ value: 0, create: create, changed: changed });
-        var p2 = new Property<Model, number>({ value: 0, create: create, changed: changed });
-        var p3 = new Property<Model, number>({ value: 0, create: create, changed: changed });
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
+        let tick = 42;
+        let create = () => tick++;
+        let p1 = new Property<Model, number>({ name: 'p1', value: 0, create, changed });
+        let p2 = new Property<Model, number>({ name: 'p2', value: 0, create, changed });
+        let p3 = new Property<Model, number>({ name: 'p3', value: 0, create, changed });
+        let m1 = new Model();
+        let m2 = new Model();
+        let m3 = new Model();
         p1.set(m1, 1);
         p1.set(m2, 2);
         p1.set(m3, 3);
@@ -517,9 +429,9 @@ describe('phosphor-properties', () => {
       });
 
       it('should invoke the coerce function on the new value', () => {
-        var coerce = (o: Model, v: number) => Math.max(0, v);
-        var p = new Property<Model, number>({ coerce: coerce });
-        var m = new Model();
+        let coerce = (o: Model, v: number) => Math.max(0, v);
+        let p = new Property<Model, number>({ name: 'p', coerce });
+        let m = new Model();
         p.set(m, -10);
         expect(p.get(m)).to.be(0);
         p.set(m, 10);
@@ -532,22 +444,53 @@ describe('phosphor-properties', () => {
         expect(p.get(m)).to.be(0);
       });
 
-      it('should invoke the compare function to compare values', () => {
-        var called = false;
-        var compare = (v1: number, v2: number) => (called = true,  v1 === v2);
-        var p = new Property<Model, number>({ value: 1, compare: compare });
-        var m = new Model();
+      it('should not invoke the compare function if there are no listeners', () => {
+        let called = false;
+        let compare = (v1: number, v2: number) => (called = true, v1 === v2);
+        let p = new Property<Model, number>({ name: 'p', value: 1, compare });
+        let m = new Model();
+        p.set(m, 42);
+        expect(called).to.be(false);
+      });
+
+      it('should invoke the compare function if there is a changed function', () => {
+        let called = false;
+        let changed = () => { };
+        let compare = (v1: number, v2: number) => (called = true, v1 === v2);
+        let p = new Property<Model, number>({ name: 'p', value: 1, compare, changed });
+        let m = new Model();
+        p.set(m, 42);
+        expect(called).to.be(true);
+      });
+
+      it('should invoke the compare function if there is a notify signal', () => {
+        let called = false;
+        let notify = new Signal<Model, IChangedArgs<number>>();
+        let compare = (v1: number, v2: number) => (called = true, v1 === v2);
+        let p = new Property<Model, number>({ name: 'p', value: 1, compare, notify });
+        let m = new Model();
+        p.set(m, 42);
+        expect(called).to.be(true);
+      });
+
+      it('should invoke the compare function if there is a changed function and notify signal', () => {
+        let called = false;
+        let changed = () => { };
+        let notify = new Signal<Model, IChangedArgs<number>>();
+        let compare = (v1: number, v2: number) => (called = true, v1 === v2);
+        let p = new Property<Model, number>({ name: 'p', value: 1, compare, changed, notify });
+        let m = new Model();
         p.set(m, 42);
         expect(called).to.be(true);
       });
 
       it('should not invoke the changed function if the value does not change', () => {
-        var called = false;
-        var changed = () => { called = true; };
-        var compare = (v1: number, v2: number) => true;
-        var p1 = new Property<Model, number>({ value: 1, changed: changed });
-        var p2 = new Property<Model, number>({ value: 1, compare: compare, changed: changed });
-        var m = new Model();
+        let called = false;
+        let changed = () => { called = true; };
+        let compare = (v1: number, v2: number) => true;
+        let p1 = new Property<Model, number>({ name: 'p1', value: 1, changed });
+        let p2 = new Property<Model, number>({ name: 'p2', value: 1, compare, changed });
+        let m = new Model();
         p1.set(m, 1);
         p1.set(m, 1);
         p2.set(m, 1);
@@ -557,32 +500,15 @@ describe('phosphor-properties', () => {
         expect(called).to.be(false);
       });
 
-      it('should not emit the static `changedSignal` if the value does not change', () => {
-        var called = false;
-        var changed = () => { called = true; };
-        var compare = (v1: number, v2: number) => true;
-        var p1 = new Property<Model, number>({ value: 1 });
-        var p2 = new Property<Model, number>({ value: 1, compare: compare });
-        var m = new Model();
-        Property.getChanged(m).connect(changed);
-        p1.set(m, 1);
-        p1.set(m, 1);
-        p2.set(m, 1);
-        p2.set(m, 2);
-        p2.set(m, 3);
-        p2.set(m, 4);
-        expect(called).to.be(false);
-      });
-
-      it('should not emit the instance `changedSignal` if the value does not change', () => {
-        var called = false;
-        var changed = () => { called = true; };
-        var compare = (v1: number, v2: number) => true;
-        var p1 = new Property<Model, number>({ value: 1 });
-        var p2 = new Property<Model, number>({ value: 1, compare: compare });
-        var m = new Model();
-        p1.getChanged(m).connect(changed);
-        p2.getChanged(m).connect(changed);
+      it('should not emit the notify signal if the value does not change', () => {
+        let called = false;
+        let changed = () => { called = true; };
+        let compare = (v1: number, v2: number) => true;
+        let notify = new Signal<Model, IChangedArgs<number>>();
+        let p1 = new Property<Model, number>({ name: 'p1', value: 1, notify });
+        let p2 = new Property<Model, number>({ name: 'p2', value: 1, compare, notify });
+        let m = new Model();
+        notify.bind(m).connect(changed);
         p1.set(m, 1);
         p1.set(m, 1);
         p2.set(m, 1);
@@ -597,11 +523,11 @@ describe('phosphor-properties', () => {
     describe('#coerce()', () => {
 
       it('should coerce the current value of the property', () => {
-        var min = 20;
-        var max = 50;
-        var coerce = (m: Model, v: number) => Math.max(min, Math.min(v, max));
-        var p = new Property<Model, number>({ value: 0, coerce: coerce });
-        var m = new Model();
+        let min = 20;
+        let max = 50;
+        let coerce = (m: Model, v: number) => Math.max(min, Math.min(v, max));
+        let p = new Property<Model, number>({ name: 'p', value: 0, coerce });
+        let m = new Model();
         p.set(m, 10);
         expect(p.get(m)).to.be(20);
         min = 30;
@@ -614,157 +540,135 @@ describe('phosphor-properties', () => {
       });
 
       it('should invoke the changed function if the value changes', () => {
-        var called = false;
-        var coerce = (m: Model, v: number) => Math.max(20, v);
-        var changed = () => { called = true };
-        var p = new Property<Model, number>({ value: 0, coerce: coerce, changed: changed });
-        var m = new Model();
+        let called = false;
+        let coerce = (m: Model, v: number) => Math.max(20, v);
+        let changed = () => { called = true };
+        let p = new Property<Model, number>({ name: 'p', value: 0, coerce, changed });
+        let m = new Model();
         p.coerce(m);
         expect(called).to.be(true);
       });
 
-      it('should emit the static `changedSignal` if the value changes', () => {
-        var called = false;
-        var coerce = (m: Model, v: number) => Math.max(20, v);
-        var changed = () => { called = true };
-        var p = new Property<Model, number>({ value: 0, coerce: coerce });
-        var m = new Model();
-        Property.getChanged(m).connect(changed);
+      it('should emit the notify signal if the value changes', () => {
+        let called = false;
+        let coerce = (m: Model, v: number) => Math.max(20, v);
+        let changed = () => { called = true };
+        let notify = new Signal<Model, IChangedArgs<number>>();
+        let p = new Property<Model, number>({ name: 'p', value: 0, coerce, notify });
+        let m = new Model();
+        notify.bind(m).connect(changed);
         p.coerce(m);
         expect(called).to.be(true);
       });
 
-      it('should emit the instance `changedSignal` if the value changes', () => {
-        var called = false;
-        var coerce = (m: Model, v: number) => Math.max(20, v);
-        var changed = () => { called = true };
-        var p = new Property<Model, number>({ value: 0, coerce: coerce });
-        var m = new Model();
-        p.getChanged(m).connect(changed);
+      it('should call the changed function before notify signal', () => {
+        let result: string[] = [];
+        let changed = () => { result.push('c1'); };
+        let changed2 = () => { result.push('c2'); };
+        let coerce = (m: Model, v: number) => Math.max(20, v);
+        let notify = new Signal<Model, IChangedArgs<number>>();
+        let p = new Property<Model, number>({ name: 'p', value: 0, coerce, changed, notify });
+        let m = new Model();
+        notify.bind(m).connect(changed2);
         p.coerce(m);
-        expect(called).to.be(true);
-      });
-
-      it('should notify in order: function -> instance -> static', () => {
-        var result: string[] = [];
-        var changed1 = () => { result.push('c1'); };
-        var changed2 = () => { result.push('c2'); };
-        var changed3 = () => { result.push('c3'); };
-        var coerce = (m: Model, v: number) => Math.max(20, v);
-        var p = new Property<Model, number>({ value: 0, coerce: coerce, changed: changed1 });
-        var m = new Model();
-        p.getChanged(m).connect(changed2);
-        Property.getChanged(m).connect(changed3);
-        p.coerce(m);
-        expect(result).to.eql(['c1', 'c2', 'c3']);
+        expect(result).to.eql(['c1', 'c2']);
       });
 
       it('should use the default value as old value if value is not yet set', () => {
-        var oldval: number;
-        var newval: number;
-        var coerce = (m: Model, v: number) => Math.max(20, v);
-        var changed = (m: Model, o: number, n: number) => { oldval = o; newval = n; };
-        var p = new Property<Model, number>({ value: 0, coerce: coerce, changed: changed });
-        var m = new Model();
+        let oldval: number;
+        let newval: number;
+        let coerce = (m: Model, v: number) => Math.max(20, v);
+        let changed = (m: Model, o: number, n: number) => { oldval = o; newval = n; };
+        let p = new Property<Model, number>({ name: 'p', value: 0, coerce, changed });
+        let m = new Model();
         p.coerce(m);
         expect(oldval).to.be(0);
         expect(newval).to.be(20);
       });
 
       it('should use the default factory for old value if value is not yet set', () => {
-        var oldval: number;
-        var newval: number;
-        var create = () => 12;
-        var coerce = (m: Model, v: number) => Math.max(20, v);
-        var changed = (m: Model, o: number, n: number) => { oldval = o; newval = n; };
-        var p = new Property<Model, number>({ create: create, coerce: coerce, changed: changed });
-        var m = new Model();
+        let oldval: number;
+        let newval: number;
+        let create = () => 12;
+        let coerce = (m: Model, v: number) => Math.max(20, v);
+        let changed = (m: Model, o: number, n: number) => { oldval = o; newval = n; };
+        let p = new Property<Model, number>({ name: 'p', create, coerce, changed });
+        let m = new Model();
         p.coerce(m);
         expect(oldval).to.be(12);
         expect(newval).to.be(20);
       });
 
       it('should prefer the default factory over default value', () => {
-        var oldval: number;
-        var newval: number;
-        var create = () => 12;
-        var coerce = (m: Model, v: number) => Math.max(20, v);
-        var changed = (m: Model, o: number, n: number) => { oldval = o; newval = n; };
-        var p = new Property<Model, number>({ value: 0, create: create, coerce: coerce, changed: changed });
-        var m = new Model();
+        let oldval: number;
+        let newval: number;
+        let create = () => 12;
+        let coerce = (m: Model, v: number) => Math.max(20, v);
+        let changed = (m: Model, o: number, n: number) => { oldval = o; newval = n; };
+        let p = new Property<Model, number>({ name: 'p', value: 0, create, coerce, changed });
+        let m = new Model();
         p.coerce(m);
         expect(oldval).to.be(12);
         expect(newval).to.be(20);
       });
 
-      it('should invoke the compare function to compare values', () => {
-        var called = false;
-        var compare = (v1: number, v2: number) => (called = true,  v1 === v2);
-        var p = new Property<Model, number>({ value: 1, compare: compare });
-        var m = new Model();
+      it('should not invoke the compare function if there are not listeners', () => {
+        let called = false;
+        let compare = (v1: number, v2: number) => (called = true,  v1 === v2);
+        let p = new Property<Model, number>({ name: 'p', value: 1, compare });
+        let m = new Model();
+        p.coerce(m);
+        expect(called).to.be(false);
+      });
+
+      it('should invoke the compare function if there is a changed function', () => {
+        let called = false;
+        let changed = () => { };
+        let compare = (v1: number, v2: number) => (called = true, v1 === v2);
+        let p = new Property<Model, number>({ name: 'p', value: 1, compare, changed });
+        let m = new Model();
+        p.coerce(m);
+        expect(called).to.be(true);
+      });
+
+      it('should invoke the compare function if there is a notify signal', () => {
+        let called = false;
+        let notify = new Signal<Model, IChangedArgs<number>>();
+        let compare = (v1: number, v2: number) => (called = true, v1 === v2);
+        let p = new Property<Model, number>({ name: 'p', value: 1, compare, notify });
+        let m = new Model();
+        p.coerce(m);
+        expect(called).to.be(true);
+      });
+
+      it('should invoke the compare function if there is a changed function and notify signal', () => {
+        let called = false;
+        let changed = () => { };
+        let notify = new Signal<Model, IChangedArgs<number>>();
+        let compare = (v1: number, v2: number) => (called = true, v1 === v2);
+        let p = new Property<Model, number>({ name: 'p', value: 1, compare, changed, notify });
+        let m = new Model();
         p.coerce(m);
         expect(called).to.be(true);
       });
 
       it('should not invoke the changed function if the value does not change', () => {
-        var called = false;
-        var changed = () => { called = true; };
-        var p = new Property<Model, number>({ value: 1, changed: changed });
-        var m = new Model();
+        let called = false;
+        let changed = () => { called = true; };
+        let p = new Property<Model, number>({ name: 'p', value: 1, changed });
+        let m = new Model();
         p.coerce(m);
         expect(called).to.be(false);
       });
 
-      it('should not emit the static `changedSignal` if the value does not change', () => {
-        var called = false;
-        var changed = () => { called = true; };
-        var p = new Property<Model, number>({ value: 1 });
-        var m = new Model();
-        Property.getChanged(m).connect(changed);
+      it('should not emit the notify signal if the value does not change', () => {
+        let called = false;
+        let changed = () => { called = true; };
+        let notify = new Signal<Model, IChangedArgs<number>>();
+        let p = new Property<Model, number>({ name: 'p', value: 1, notify });
+        let m = new Model();
+        notify.bind(m).connect(changed);
         p.coerce(m);
-        expect(called).to.be(false);
-      });
-
-      it('should not emit the instance `changedSignal` if the value does not change', () => {
-        var called = false;
-        var changed = () => { called = true; };
-        var p = new Property<Model, number>({ value: 1 });
-        var m = new Model();
-        p.getChanged(m).connect(changed);
-        p.coerce(m);
-        expect(called).to.be(false);
-      });
-
-    });
-
-    context('silent', () => {
-
-      it('should still invoke the static changed function', () => {
-        var called = false;
-        var changed = () => { called = true; };
-        var p = new Property<Model, number>({ silent: true, changed: changed });
-        var m = new Model();
-        p.set(m, 42);
-        expect(called).to.be(true);
-      });
-
-      it('should not invoke the static `changedSignal`', () => {
-        var called = false;
-        var changed = () => { called = true; };
-        var p = new Property<Model, number>({ silent: true });
-        var m = new Model();
-        Property.getChanged(m).connect(changed);
-        p.set(m, 42);
-        expect(called).to.be(false);
-      });
-
-      it('should not invoke the instance `changedSignal`', () => {
-        var called = false;
-        var changed = () => { called = true; };
-        var p = new Property<Model, number>({ silent: true });
-        var m = new Model();
-        p.getChanged(m).connect(changed);
-        p.set(m, 42);
         expect(called).to.be(false);
       });
 
@@ -775,60 +679,60 @@ describe('phosphor-properties', () => {
   describe('clearPropertyData()', () => {
 
     it('should clear all property data for a property owner', () => {
-        var p1 = new Property<Model, number>({ value: 42 });
-        var p2 = new Property<Model, number>({ value: 42 });
-        var p3 = new Property<Model, number>({ value: 42 });
-        var m1 = new Model();
-        var m2 = new Model();
-        var m3 = new Model();
-        p1.set(m1, 1);
-        p1.set(m2, 2);
-        p1.set(m3, 3);
-        p2.set(m1, 4);
-        p2.set(m2, 5);
-        p2.set(m3, 6);
-        p3.set(m1, 7);
-        p3.set(m2, 8);
-        p3.set(m3, 9);
-        expect(p1.get(m1)).to.be(1);
-        expect(p1.get(m2)).to.be(2);
-        expect(p1.get(m3)).to.be(3);
-        expect(p2.get(m1)).to.be(4);
-        expect(p2.get(m2)).to.be(5);
-        expect(p2.get(m3)).to.be(6);
-        expect(p3.get(m1)).to.be(7);
-        expect(p3.get(m2)).to.be(8);
-        expect(p3.get(m3)).to.be(9);
-        clearPropertyData(m1);
-        expect(p1.get(m1)).to.be(42);
-        expect(p1.get(m2)).to.be(2);
-        expect(p1.get(m3)).to.be(3);
-        expect(p2.get(m1)).to.be(42);
-        expect(p2.get(m2)).to.be(5);
-        expect(p2.get(m3)).to.be(6);
-        expect(p3.get(m1)).to.be(42);
-        expect(p3.get(m2)).to.be(8);
-        expect(p3.get(m3)).to.be(9);
-        clearPropertyData(m2);
-        expect(p1.get(m1)).to.be(42);
-        expect(p1.get(m2)).to.be(42);
-        expect(p1.get(m3)).to.be(3);
-        expect(p2.get(m1)).to.be(42);
-        expect(p2.get(m2)).to.be(42);
-        expect(p2.get(m3)).to.be(6);
-        expect(p3.get(m1)).to.be(42);
-        expect(p3.get(m2)).to.be(42);
-        expect(p3.get(m3)).to.be(9);
-        clearPropertyData(m3);
-        expect(p1.get(m1)).to.be(42);
-        expect(p1.get(m2)).to.be(42);
-        expect(p1.get(m3)).to.be(42);
-        expect(p2.get(m1)).to.be(42);
-        expect(p2.get(m2)).to.be(42);
-        expect(p2.get(m3)).to.be(42);
-        expect(p3.get(m1)).to.be(42);
-        expect(p3.get(m2)).to.be(42);
-        expect(p3.get(m3)).to.be(42);
+      let p1 = new Property<Model, number>({ name: 'p1', value: 42 });
+      let p2 = new Property<Model, number>({ name: 'p2', value: 42 });
+      let p3 = new Property<Model, number>({ name: 'p3', value: 42 });
+      let m1 = new Model();
+      let m2 = new Model();
+      let m3 = new Model();
+      p1.set(m1, 1);
+      p1.set(m2, 2);
+      p1.set(m3, 3);
+      p2.set(m1, 4);
+      p2.set(m2, 5);
+      p2.set(m3, 6);
+      p3.set(m1, 7);
+      p3.set(m2, 8);
+      p3.set(m3, 9);
+      expect(p1.get(m1)).to.be(1);
+      expect(p1.get(m2)).to.be(2);
+      expect(p1.get(m3)).to.be(3);
+      expect(p2.get(m1)).to.be(4);
+      expect(p2.get(m2)).to.be(5);
+      expect(p2.get(m3)).to.be(6);
+      expect(p3.get(m1)).to.be(7);
+      expect(p3.get(m2)).to.be(8);
+      expect(p3.get(m3)).to.be(9);
+      clearPropertyData(m1);
+      expect(p1.get(m1)).to.be(42);
+      expect(p1.get(m2)).to.be(2);
+      expect(p1.get(m3)).to.be(3);
+      expect(p2.get(m1)).to.be(42);
+      expect(p2.get(m2)).to.be(5);
+      expect(p2.get(m3)).to.be(6);
+      expect(p3.get(m1)).to.be(42);
+      expect(p3.get(m2)).to.be(8);
+      expect(p3.get(m3)).to.be(9);
+      clearPropertyData(m2);
+      expect(p1.get(m1)).to.be(42);
+      expect(p1.get(m2)).to.be(42);
+      expect(p1.get(m3)).to.be(3);
+      expect(p2.get(m1)).to.be(42);
+      expect(p2.get(m2)).to.be(42);
+      expect(p2.get(m3)).to.be(6);
+      expect(p3.get(m1)).to.be(42);
+      expect(p3.get(m2)).to.be(42);
+      expect(p3.get(m3)).to.be(9);
+      clearPropertyData(m3);
+      expect(p1.get(m1)).to.be(42);
+      expect(p1.get(m2)).to.be(42);
+      expect(p1.get(m3)).to.be(42);
+      expect(p2.get(m1)).to.be(42);
+      expect(p2.get(m2)).to.be(42);
+      expect(p2.get(m3)).to.be(42);
+      expect(p3.get(m1)).to.be(42);
+      expect(p3.get(m2)).to.be(42);
+      expect(p3.get(m3)).to.be(42);
     });
 
   });


### PR DESCRIPTION
This is not ready for merge until I'm done with tests and README examples.

This is a mildly breaking change which requires a 2.0 release.

This changes are born from our discussions today on the Jupyter notebook design and the need to specify change notification semantics of interfaces, without requiring they know about phosphor properties (knowing about signals is fine).

Summary of changes:
1. The default static per-object `Property.changed` attached signal is gone.
2. The default per-property `changed` signal is gone.
3. Property metadata is gone.
4. A property `name` is now required.
5. A per-property signal is optional and can be provided as part of the constructor options.
6. The arguments object emitted for the signal in (5) includes the property `name` instead of property instance.

(5) and (6) are the important changes. It allows code which *does use* properties to be compatible with interfaces which define state changed signals, as these signals will typically have a changed args interface which is compatible with the property changed signal (since it uses a string name). It also allows the developer to specify, on a per-property basis, whether that property should notify, and exactly which signal the property should use when it notifies. This means multiple properties may share the same signal.

For example, let's say we have this interface definition which needs to be implemented, and which has no knowledge of phosphor properties:

```typescript
interface IStateArgs {
  name: string;
  oldValue: any;
  newValue: any;
}


interface ISomeObj {
  stateChanged: ISignal<ISomeObj, IStateArgs>;
  value: number;
  text: string;
}
```

That interface **can** be implemented using phosphor properties, while still being implementable by others:

```typescript
class MyObj implments ISomeObj {

  static stateChangedSignal = new Signal<MyObj, IChangedArgs<any>>();

  static valueProperty = new Property<MyObj, number>({
    name: 'value',
    value: 42,
    notify: MyObj.stateChangedSignal,
  });

  static textProperty = new Property<MyObj, string>({
    name: 'text',
    value: 'Foo',
    notify: MyObj.stateChangedSignal,
  });

  get stateChanged(): ISignal<ISomeObj, IStateArgs> {
    return MyObj.stateChangedSignal.bind(this);
  }

  get value(): number {
    return MyObj.valueProperty.get(this);
  }

  set value(value: number) {
    MyObj.valueProperty.set(this, number);
  }

  get text(): number {
    return MyObj.textProperty.get(this);
  }

  set text(value: number) {
    MyObj.textProperty.set(this, number);
  }
}


class OtherObj implments ISomeObj {

  static stateChangedSignal = new Signal<MyObj, IStateArgs>();

  get stateChanged(): ISignal<ISomeObj, IStateArgs> {
    return OtherObj.stateChangedSignal.bind(this);
  }

  get value(): number {
    return this._value;
  }

  set value(value: number) {
    if (value === this._value) {
      return;
    }
    let old = this._value;
    this._value = value;
    this.stateChanged.emit({ name: 'value', oldValue: old, newValue: value });
  }

  get text(): number {
    return this._text;
  }

  set text(value: number) {
    if (value === this._text) {
      return;
    }
    let old = this._text;
    this._text = value;
    this.stateChanged.emit({ name: 'text', oldValue: old, newValue: value });
  }

  private _value = 42;
  private _text = 'Foo';
}
```

ping @ellisonbg @jasongrout @sylvaincorlay @jdfreder @blink1073 @dwillmer @afshin @carreau